### PR TITLE
Fixing typo (I assume) in bouncycastle dependency doc.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Additionally, in many cases you will need the following two artifacts, which pro
 support::
 
     libraryDependencies ++= Seq(
-      "org.bouncycastle" % "bcprov-jdk16" % "1.54",
+      "org.bouncycastle" % "bcprov-jdk15on" % "1.54",
       "com.jcraft" % "jzlib" % "1.1.3"
     )
 


### PR DESCRIPTION
The doc for the dependency is mentioning the older jdk16 bouncycastle series, not the (counterintuitively) newer jdk15on.
