### PR TITLE
Add installation instructions for JCE on OSX

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -176,6 +176,7 @@ encounter exceptions like this:
             at net.schmizz.sshj.common.KeyType$3.readPubKeyFromBuffer(KeyType.java:144) ~[sshj-0.12.0.jar:na]
             ... 7 common frames omitted
 
+On OSX with homebrew, you can install JCE by running :code:`brew cask install jce-unlimited-strength-policy`.
 
 License
 -------


### PR DESCRIPTION
I hit the aforementioned `key spec not recognised` issue and had to install JCE.

It's much easier to do it this way with homebrew than manually download from Oracle and put into JAVA_HOME. Might be nice to include it here?